### PR TITLE
Add analysis on SonarCloud.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ src/software/firmware/*.ods
 src/software/firmware/*.csv#
 src/software/firmware/*.ods#
 src/software/control/target/*
+build*/*
+.scannerwork

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,45 @@
+language: generic
+before_install:
+  - wget http://downloads.arduino.cc/arduino-cli/arduino-cli_latest_Linux_64bit.tar.gz
+  - tar xf arduino-cli_latest_Linux_64bit.tar.gz
+  - mkdir -p $HOME/bin
+  - mv arduino-cli $HOME/bin/arduino-cli
+  - export PATH=$PATH:$HOME/bin
+  - arduino-cli core update-index
+  - arduino-cli config init --additional-urls https://github.com/stm32duino/BoardManagerFiles/raw/master/STM32/package_stm_index.json
+  - arduino-cli config dump
+  - arduino-cli core update-index
+  - arduino-cli core install STM32:stm32
+  - arduino-cli lib install LiquidCrystal
+  - arduino-cli lib install "Analog Buttons"
+  - arduino-cli lib install OneButton
+  - sed -i '/recipe.output.tmp_file={build.project_name}.hex/d' "$HOME/.arduino15/packages/STM32/hardware/stm32/1.8.0/platform.txt"
+  - sed -i '/recipe.output.save_file={build.project_name}.{build.variant}.hex/d' "$HOME/.arduino15/packages/STM32/hardware/stm32/1.8.0/platform.txt"
+install:
+  - mkdir -p $HOME/Arduino/libraries
+  - ln -s $PWD $HOME/Arduino/libraries/.
+
+addons:
+  sonarcloud:
+    organization: "ReplaceByYourOrganization"
+    token:
+      secure: "ReplaceByYourEncriptedToken" # encrypted value of your token
+
+# Cache PlatformIO packages using Travis CI container-based infrastructure
+sudo: false
+cache:
+    directories:
+        - '$HOME/.sonar/cache/hw1'
+        - '$HOME/.sonar/cache/hw2'
+script:
+    - |
+      if [[ $TRAVIS_PULL_REQUEST_SLUG == "" || $TRAVIS_PULL_REQUEST_SLUG == "covid-response-projects/covid-respirator" ]]; then
+        # HW2 analysis
+        arduino-cli cache clean
+        build-wrapper-linux-x86-64 --out-dir sonarcloud/hw2/bo bash sonarcloud/hw2/build.sh
+        sonar-scanner -Dproject.settings=sonarcloud/hw2/sonar-project.properties -Dsonar.cfamily.cache.path=$HOME/.sonar/cache/hw2
+        # HW1 analysis
+        arduino-cli cache clean
+        build-wrapper-linux-x86-64 --out-dir sonarcloud/hw1/bo bash sonarcloud/hw1/build.sh
+        sonar-scanner -Dproject.settings=sonarcloud/hw1/sonar-project.properties -Dsonar.cfamily.cache.path=$HOME/.sonar/cache/hw1
+      fi

--- a/sonarcloud/hw1/build.sh
+++ b/sonarcloud/hw1/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+sed -Ei 's/#define HARDWARE_VERSION [0-9]+/#define HARDWARE_VERSION 1/' src/software/firmware/includes/config.h
+sed -Ei 's/#define MODE .+/#define MODE MODE_PROD/' src/software/firmware/includes/config.h
+arduino-cli compile --build-path $PWD/buildProdhw1 --fqbn STM32:stm32:Nucleo_64:opt=o3std,pnum=NUCLEO_F411RE --verbose src/software/firmware/srcs/respirator.cpp --output src/software/firmware/output/respirator-production

--- a/sonarcloud/hw1/sonar-project.properties
+++ b/sonarcloud/hw1/sonar-project.properties
@@ -1,0 +1,7 @@
+sonar.projectKey=covid_HW1
+sonar.projectVersion=1.0-SNAPSHOT
+sonar.sources=.
+sonar.cfamily.build-wrapper-output=sonarcloud/hw1/bo
+sonar.cfamily.cache.enabled=true
+sonar.cfamily.threads=8
+sonar.scm.exclusions.disabled=true

--- a/sonarcloud/hw2/build.sh
+++ b/sonarcloud/hw2/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+sed -Ei 's/#define HARDWARE_VERSION [0-9]+/#define HARDWARE_VERSION 2/' src/software/firmware/includes/config.h
+sed -Ei 's/#define MODE .+/#define MODE MODE_PROD/' src/software/firmware/includes/config.h
+arduino-cli compile --build-path $PWD/buildProdhw2 --fqbn STM32:stm32:Nucleo_64:opt=o3std,pnum=NUCLEO_F411RE --verbose src/software/firmware/srcs/respirator.cpp --output src/software/firmware/output/respirator-production

--- a/sonarcloud/hw2/sonar-project.properties
+++ b/sonarcloud/hw2/sonar-project.properties
@@ -1,0 +1,7 @@
+sonar.projectKey=covid_HW2
+sonar.projectVersion=1.0-SNAPSHOT
+sonar.sources=.
+sonar.cfamily.build-wrapper-output=sonarcloud/hw2/bo
+sonar.cfamily.cache.enabled=true
+sonar.cfamily.threads=8
+sonar.scm.exclusions.disabled=true


### PR DESCRIPTION
@Mefl As discussed on [SonarSource Community forum](https://community.sonarsource.com/t/adding-a-source-code-analysis-for-iot/22143/7), here's the PR to activate SonarCloud analysis on the repo, using Travis-CI.

The following steps should be enough to make this work:
1. Activate Travis-CI (https://travis-ci.com) for your repo
   * Follow steps 1, 2 and 3 of [the tutorial](https://docs.travis-ci.com/user/tutorial/#to-get-started-with-travis-ci-using-github)
2. On the [Settings page of your repo in Travis](https://travis-ci.com/github/covid-response-projects/covid-respirator/settings), set a SonarCloud token as a SONAR_TOKEN environment variable
   * You can generate a SonarCloud token on https://sonarcloud.io/account
3. Merge this PR into your master branch, this will kick in a build on Travis and a couple of minutes later you will have the analysis available on [project homepage](https://sonarcloud.io/dashboard?id=covid-response-projects_covid-respirator)

**Important note**: for the SonarCloud analysis to run, it's mandatory that the Platform IO build succeeds because it needs information from the compiler. Currently, your master branch is broken (see [the latest run](https://github.com/covid-response-projects/covid-respirator/runs/540293426)), so you should fix this prior to merging this PR - otherwise you won't get results.

Please feel free to ping me if anything does not work as expected!