### PR TITLE
Add redirection to documentation

### DIFF
--- a/.github/docs-firmware-redirect.html 
+++ b/.github/docs-firmware-redirect.html 
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to documentation</title>
+<meta http-equiv="refresh" content="0; URL=https://covid-response-projects.github.io/covid-respirator/docs/software/firmware/html/files.html">
+<link rel="canonical" href="https://covid-response-projects.github.io/covid-respirator/docs/software/firmware/html/files.html"> 

--- a/.github/workflows/firmware-docs.yml
+++ b/.github/workflows/firmware-docs.yml
@@ -17,6 +17,10 @@ jobs:
         run: |
           mkdir -p local/docs/software/firmware
 
+      - name: Copy redirection
+        run: |
+          cp .github/docs-firmware-redirect.html local/docs/software/firmware/index.html
+
       - name: Generate documentation for firmware
         uses: mattnotmitt/doxygen-action@v1
         with:


### PR DESCRIPTION
I struggled to find the documentation which is on https://covid-response-projects.github.io/covid-respirator/docs/software/firmware/html/files.html.

This PR should add a redirection from https://covid-response-projects.github.io/covid-respirator/docs/ to the real documentation.

May even be better to do it on /covid-respirator/ by removing the `docs` target folder and copy it as well.

It should be working as I got the file copied on https://github.com/yannbertrand/covid-respirator/tree/gh-pages/docs 🙂.