### PR TITLE
start telemetry inclusion in debug.h messages convert to serial library

### DIFF
--- a/src/software/firmware/srcs/pressure_controller.cpp
+++ b/src/software/firmware/srcs/pressure_controller.cpp
@@ -167,9 +167,8 @@ void PressureController::compute(uint16_t p_centiSec) {
     }
     safeguards(p_centiSec);
 
-    DBG_PHASE_PRESSION(m_cycleNb, p_centiSec, 1u, m_phase, m_subPhase, m_pressure,
-                       m_blower_valve.command, m_blower_valve.position, m_patient_valve.command,
-                       m_patient_valve.position)
+	DBG_TELEMERTY_DATA(m_cycleNb, p_centiSec, 1u, m_phase, m_subPhase, m_pressure,
+	m_blower_valve.position, m_patient_valve.position, m_blower->getSpeed(), getBatteryVoltage())
 
     executeCommands();
 


### PR DESCRIPTION
Hello,
I have tried to start an implementation based on what was already done in debug.h. Sorry if it is not consistent to you, I was trying to prepare the field for V2. 
Regarding specification in #120 :
* alarm Trap not implemented in this PR
* for state snapshot and alarm trap: don't know where to implement it (respirator.cpp or pressure_controller.cpp?)
* for state snapshot : not sure what a cycle is -> 10ms or 3 seconds? 

I also wanted to point out that the data transmission over serial can take up to 3ms (at 115200 baudrate) of the cycle that last for 10ms which is almost 1/3 of the CPU usage. I would recommand to see whether you can use the DMA for the serial TX in order to avoid the CPU usage. Maybe someone from ST or the Arduino community can help. I have not such experience with STM32duino.

Thomas