### PR TITLE
Control: use systick field of messages instead of getting a local time

### DIFF
--- a/src/software/control/src/chip/mod.rs
+++ b/src/software/control/src/chip/mod.rs
@@ -1,0 +1,38 @@
+use chrono::{offset::Utc, DateTime};
+
+pub struct Chip {
+    pub boot_time: Option<DateTime<Utc>>,
+    pub last_tick: u64,
+}
+
+impl Chip {
+    pub fn new() -> Chip {
+        Chip {
+            boot_time: None,
+            last_tick: 0,
+        }
+    }
+
+    fn update_boot_time(&mut self) {
+        let now = Utc::now();
+        let duration = chrono::Duration::microseconds(self.last_tick as i64);
+        self.boot_time = Some(now - duration);
+    }
+
+    #[inline(always)]
+    pub fn update_tick(&mut self, tick: u64) {
+        if tick < self.last_tick {
+            self.reset(tick);
+        } else {
+            self.last_tick = tick;
+            if self.boot_time.is_none() {
+                self.update_boot_time();
+            }
+        }
+    }
+
+    pub fn reset(&mut self, new_tick: u64) {
+        self.last_tick = new_tick;
+        self.update_boot_time();
+    }
+}

--- a/src/software/control/src/main.rs
+++ b/src/software/control/src/main.rs
@@ -14,6 +14,7 @@ extern crate conrod_core;
 extern crate conrod_winit;
 extern crate image;
 
+mod chip;
 mod config;
 mod display;
 mod serial;


### PR DESCRIPTION
All time has been switched to UTC if we ever want to manipulate it
later. Because we do not display the date on the graph, that's ok for
now.

We also guess the boot time if we do not have one yet based on the last `systick` we received. There are chances we miss the BootMessage (the telemetry crate might not open a socket quick enough to catch it or our program might crash or been restarted). If we ever receive a `systick` lower than our last one, we reset our state.