### PR TITLE
Control: display various messages following the telemetry state

### DIFF
--- a/src/software/control/src/display/widgets.rs
+++ b/src/software/control/src/display/widgets.rs
@@ -35,7 +35,11 @@ widget_ids!(pub struct Ids {
   peep_parent,
   peep_title,
   peep_value,
-  peep_unit
+  peep_unit,
+
+  no_data,
+  stopped,
+  error
 });
 
 pub struct WidgetConfig<'a> {
@@ -183,4 +187,40 @@ pub fn create_widget(ui: &mut conrod_core::UiCell, config: WidgetConfig) -> f64 
         .set(config.ids.3, ui);
 
     10.0 + 120.0
+}
+
+pub fn create_no_data_widget(mut ui: conrod_core::UiCell, ids: Ids, fonts: &Fonts) {
+    let mut text_style = conrod_core::widget::primitive::text::Style::default();
+    text_style.font_id = Some(Some(fonts.bold));
+    text_style.color = Some(color::WHITE);
+    text_style.font_size = Some(30);
+    widget::Text::new("Device disconnected or no data received")
+        .color(color::WHITE)
+        .middle()
+        .with_style(text_style)
+        .set(ids.no_data, &mut ui);
+}
+
+pub fn create_stopped_widget(mut ui: conrod_core::UiCell, ids: Ids, fonts: &Fonts) {
+    let mut text_style = conrod_core::widget::primitive::text::Style::default();
+    text_style.font_id = Some(Some(fonts.bold));
+    text_style.color = Some(color::WHITE);
+    text_style.font_size = Some(30);
+    widget::Text::new("Press start to begin")
+        .color(color::WHITE)
+        .middle()
+        .with_style(text_style)
+        .set(ids.stopped, &mut ui);
+}
+
+pub fn create_error_widget(mut ui: conrod_core::UiCell, ids: Ids, fonts: &Fonts, error: String) {
+    let mut text_style = conrod_core::widget::primitive::text::Style::default();
+    text_style.font_id = Some(Some(fonts.bold));
+    text_style.color = Some(color::WHITE);
+    text_style.font_size = Some(30);
+    widget::Text::new(&format!("An error happened:\n{}", error)) // using \n instead of the wrap methods because I couldn't make them work
+        .color(color::WHITE)
+        .align_top() // Aligned to top otherwise I can't make the line breaks work
+        .with_style(text_style)
+        .set(ids.error, &mut ui);
 }

--- a/src/software/telemetry/src/bin.rs
+++ b/src/software/telemetry/src/bin.rs
@@ -14,7 +14,6 @@ use std::fs::OpenOptions;
 use std::io::BufWriter;
 use std::sync::mpsc::{Receiver, Sender, TryRecvError};
 
-use telemetry::structures::*;
 use telemetry::*;
 
 #[derive(Clap)]
@@ -76,7 +75,7 @@ fn main() {
 }
 
 fn debug(cfg: Debug) {
-    let (tx, rx): (Sender<TelemetryMessage>, Receiver<TelemetryMessage>) =
+    let (tx, rx): (Sender<TelemetryChannelType>, Receiver<TelemetryChannelType>) =
         std::sync::mpsc::channel();
     std::thread::spawn(move || {
         gather_telemetry(&cfg.port, tx, None);
@@ -104,7 +103,7 @@ fn record(cfg: Record) {
         .unwrap();
     let file_buffer = BufWriter::new(file);
 
-    let (tx, rx): (Sender<TelemetryMessage>, Receiver<TelemetryMessage>) =
+    let (tx, rx): (Sender<TelemetryChannelType>, Receiver<TelemetryChannelType>) =
         std::sync::mpsc::channel();
     std::thread::spawn(move || {
         gather_telemetry(&cfg.port, tx, Some(file_buffer));
@@ -126,7 +125,7 @@ fn record(cfg: Record) {
 
 fn play(cfg: Play) {
     let file = File::open(cfg.input).unwrap();
-    let (tx, rx): (Sender<TelemetryMessage>, Receiver<TelemetryMessage>) =
+    let (tx, rx): (Sender<TelemetryChannelType>, Receiver<TelemetryChannelType>) =
         std::sync::mpsc::channel();
     std::thread::spawn(move || {
         gather_telemetry_from_file(file, tx);

--- a/src/software/telemetry/src/lib.rs
+++ b/src/software/telemetry/src/lib.rs
@@ -148,7 +148,7 @@ pub fn display_message(message: TelemetryChannelType) {
             debug!("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
         }
         Err(e) => {
-            info!("An error occured: {:?}", e);
+            warn!("An error occurred: {:?}", e);
         }
     }
 }


### PR DESCRIPTION
It introduces:
    - A device disconnected or no Data received message
    - A "press start to begin" message when the makair is stopped
    - An error message when an unknown error happens

@dsferruzza there are also some changes in the telemetry crate to report the serial errors it gets