### PR TITLE
Make control window more flexible when not in fullscreen mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ The Control Unit should be built and ran on the Raspberry Pi 4 using instruction
 | Runtime | Version | Major Changes | Ready? | Contributors |
 | ------- | ------- | ------------- | ------ | ------------ |
 | [Ventilator Firmware](./src/software/firmware) | V1.5.x | Initial test working | ✅ | [Emmanuel Feller](https://github.com/Mefl) + [Gautier de Saint Martin Lacaze](https://github.com/jabby) + [David Sferruzza](https://github.com/dsferruzza) + [Baptiste Jamin](https://github.com/baptistejamin) + [Gabriel Moneyron](https://github.com/Benhalor)
-| [Control Unit](./src/software/control) | V1.1.x | Operational initial release | ✅ | [Valerian Saliou](https://github.com/valeriansaliou) + [Quentin Adam](https://github.com/waxzce) + [Arnaud Lefebvre](https://github.com/BlackYoup)
+| [Control Unit](./src/software/control) | V1.1.x | Operational initial release | ✅ | [Valerian Saliou](https://github.com/valeriansaliou) + [Quentin Adam](https://github.com/waxzce) + [Arnaud Lefebvre](https://github.com/BlackYoup) + [David Sferruzza](https://github.com/dsferruzza)
 | [Telemetry Library](./src/software/telemetry) | V1.0.0 | Working serial parsing from firmware | ✅ | [David Sferruzza](https://github.com/dsferruzza)
 
 # Schemes

--- a/src/software/control/src/display/window.rs
+++ b/src/software/control/src/display/window.rs
@@ -67,9 +67,9 @@ impl DisplayWindow {
                 .unwrap(),
             ))
             .with_dimensions((DISPLAY_WINDOW_SIZE_WIDTH, DISPLAY_WINDOW_SIZE_HEIGHT).into())
-            .with_decorations(false)
+            .with_decorations(!APP_ARGS.fullscreen)
             .with_resizable(false)
-            .with_always_on_top(true);
+            .with_always_on_top(APP_ARGS.fullscreen);
 
         let window = if APP_ARGS.fullscreen {
             let primary_monitor = events_loop.get_primary_monitor();


### PR DESCRIPTION
The point here is just to ease development. When in production on the RPi, the UI is launched with `--fullscreen` anyway.